### PR TITLE
fix time presentation bug.

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -84,6 +84,6 @@ module.exports = {
     return config
   },
   getDate() {
-    return moment().format('YYYY-MM-DD hh:mm:ss')
+    return moment().format('YYYY-MM-DD HH:mm:ss')
   },
 }


### PR DESCRIPTION
- Origin code will confuse `2018-09-11 01:28:41` and `2018-09-11 13:28:41`, it cannot distinguish `am` and `pm`.